### PR TITLE
Fix broken link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -11,7 +11,7 @@
 
 ZKsync Era is a Layer 2 zkEVM designed to scale blockchains like the internet. With ZKsync Era, EVM projects can easily take advantage of high-speed, low-cost transactions with the same security guarantees as Ethereum. Join us on our mission to accelerate mass adoption.
 
-[ZKsync Era Documentation](https://era.zksync.io/docs/)
+[ZKsync Era Documentation](https://docs.zksync.io/build)
 
 [Bridge funds to Era](https://bridge.zksync.io)
 


### PR DESCRIPTION
The link: https://docs.zksync.io/docs/

returned a 404 error