### PR TITLE
Fix broken links

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -15,8 +15,8 @@ Founded by seasoned software architects and backed by top-tier investors, Matter
 
 ZKsync Era is a Layer 2 zkEVM designed to scale blockchains like the internet. With ZKsync Era, EVM projects can easily take advantage of high-speed, low-cost transactions with the same security guarantees as Ethereum. Join us on our mission to accelerate mass adoption.
 
-[ZKsync Era Documentation](https://era.zksync.io/docs/)
+[ZKsync Era Documentation](https://docs.zksync.io)
 
 [Bridge funds to Era](https://bridge.zksync.io)
 
-[ZKsync Lite Documentation](https://docs.zksync.io/)
+[ZKsync Lite Documentation](https://docs.lite.zksync.io)


### PR DESCRIPTION
ZKsync Era link goes to a "not found" page.
ZKsync Lite goes to ZKsync Era's docs.

They are fixed in this commit.