### PR TITLE
docs: Update README.md with discord link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -6,6 +6,8 @@
 [![Live on Mainnet](https://img.shields.io/badge/Era%20Bridge-Live%20on%20Mainnet-blue)](https://bridge.zksync.io)
 [![Live on Mainnet](https://img.shields.io/badge/zkLite%20Checkout-Live%20on%20Mainnet-blue)](https://checkout.zksync.io)
 [![Follow us!](https://img.shields.io/twitter/follow/zksync?color=%238C8DFC&label=Follow%20%40zkSync&logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iNDMiIGhlaWdodD0iMjUiIHZpZXdCb3g9IjAgMCA0MyAyNSIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik00Mi42NTM5IDEyLjQ5MTVMMzAuODM3OCAwLjcxNjc0M1Y5LjM0TDE5LjEwNTUgMTcuOTczOUwzMC44Mzc4IDE3Ljk4MlYyNC4yNjYyTDQyLjY1MzkgMTIuNDkxNVoiIGZpbGw9IiM0RTUyOUEiLz4KPHBhdGggZmlsbC1ydWxlPSJldmVub2RkIiBjbGlwLXJ1bGU9ImV2ZW5vZGQiIGQ9Ik0wLjk5ODA0NyAxMi40ODcyTDEyLjgxNDEgMjQuMjYxOVYxNS43MDhMMjQuNTQ2NSA3LjAwNDdMMTIuODE0MSA2Ljk5NjY0VjAuNzEyNDYzTDAuOTk4MDQ3IDEyLjQ4NzJaIiBmaWxsPSIjOEM4REZDIi8%2BCjwvc3ZnPgo%3D&style=flat)](https://twitter.com/zksync)
+[![Join us on Discord!](https://img.shields.io/badge/Discord-Click%20to%20Join-blue?logo=discord&style=flat)](https://join.zksync.dev/)
+
 
 ## About Matter Labs
 


### PR DESCRIPTION
This PR is for adding a link to join the Discord community, which redirects users to the join.zksync.dev site. 

On README , there is  a link to Era Explorer , Era Bridge,  ZkLite Checkout, Follow Twitter, But Not Discord. I thought It would be useful , So that I added.
This update makes it easier for users to find and access all social links directly from the GitHub README. 
                                                                                        Thanks